### PR TITLE
Add organization-wide PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!---
+Thanks for creating a pull request!
+
+Please start your PR title with the appropriate prefix as specified by [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification):
+
+chore: [your title]
+docs: [your title]
+feat: [your title]
+fix: [your title]
+refactor: [your title]
+test: [your title]
+-->
+
+
+## Intent
+<!---
+Please describe what you want to achieve here.
+Keep your PR limited to one logical change.
+For example, if you add a feature, don't include fixes you made along the way
+Please open another PR for more contributions.
+-->
+
+## Description
+<!--- 
+For complex PRs, please describe what you did to achieve your goal here.
+Did you consider different approaches, where there any trade-offs you made?
+More information about why you implemented your solution the way you did helps reviewers.
+This section can be removed for obvious changes like typo fixes.
+-->
+
+## Checklist
+<!--- 
+Please make sure all that apply are checked.
+-->
+- [ ] Documentation in README, crate, module, function and/or other locations added/adapted.
+- [ ] New tests added and/or existing tests adapted.
+- [ ] PR is limited to a single logical change.
+- [ ] At least the first commit has a clear title and a descriptive message containing reasoning for the change. This will be included in the final commit message after squashing and merging.


### PR DESCRIPTION
With an organization-wide PR template, we have a good default for all our repositories.