### PR TITLE
chore: point out CHANGELOG.md requirements

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,8 @@ Thanks for creating a pull request!
 
 ## TODO
 
+ - 🚧 Consider if this PR is release-notes-worthy, and update CHANGELOG.md if so.
+
  - 🚧 Added/updated relevant documentation in README, crate, module, function and/or other locations.
 
  - 🚧 New tests added and/or existing tests adapted.


### PR DESCRIPTION
I don't think this will help a lot nudging us towards following [our new changelog rules](https://engineering-handbook-bia.pages.dev/general_practices#release-notes-tracking), but it's something? Ideas welcome.